### PR TITLE
feat: init CI and CD pipeline

### DIFF
--- a/.github/workflows/dev-tf-apply.yml
+++ b/.github/workflows/dev-tf-apply.yml
@@ -83,6 +83,3 @@ jobs:
         run: terraform apply -auto-approve
         env:
           TF_VAR_location: ${{ secrets.AWS_REGION }}
-          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
-          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
-          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}

--- a/.github/workflows/dev-tf-apply.yml
+++ b/.github/workflows/dev-tf-apply.yml
@@ -1,0 +1,89 @@
+name: Dev - Terraform Apply
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "dev/**"
+      - ".github/workflows/dev-tf-apply.yml"
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: The Pull Request number
+        required: true
+        type: number
+
+permissions:
+  id-token: write # This is required for requesting the JWT (OIDC)
+  contents: read
+  pull-requests: write
+
+jobs:
+  dev_terraform_apply:
+    environment:
+      name: Development
+    env:
+      tf_version: "1.10.2"
+      tf_dir: "dev"
+    defaults:
+      run:
+        working-directory: ${{ env.tf_dir }}
+
+    runs-on: ubuntu-22.04
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+      - id: checkout_common_action
+        name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          repository: Innovate-Future-Foundation/common-action
+          path: common-action
+
+      - id: extract_pr_info
+        name: Extract PR Info
+        uses: ./common-action/extract-pr-info
+        with:
+          github_token: ${{ github.token }}
+          pr_number: ${{ inputs.pr_number }}
+
+      - id: tf_prep
+        name: Terraform setup using oidc role
+        uses: ./common-action/setup-tf-aws
+        with:
+          terraform_dir: ${{ env.tf_dir }}
+          terraform_version: ${{ env.tf_version }}
+          backend_region: ${{ secrets.TF_BACKEND_REGION }}
+          backend_role_arn: "arn:aws:iam::${{ secrets.AWS_DEV_ORG_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          backend_state_bucket: ${{ secrets.TF_BACKEND_STATE_BUCKET }}
+          backend_lockid_table: ${{ secrets.TF_BACKEND_LOCKID_TABLE }}
+
+      - id: dl_tf_plan
+        if: steps.extract_pr_info.outputs.PR_NUMBER != 0
+        name: Download Plan from S3
+        run: |
+          echo "Download Tfplan File"
+          # aws s3 cp s3://${{ secrets.WORKFLOW_TEMP_BUCKET }}/plans/plan-${{ steps.extract_pr_info.outputs.PR_NUMBER }}_${{ env.tf_dir }} tfplan
+          if [ $? -ne 0 ]; then
+            echo "Failed to retrieve planfile. It may have expired or been deleted."
+            exit 1
+          fi
+
+      - id: tf_apply_tfplan
+        if: steps.extract_pr_info.outputs.PR_NUMBER != 0
+        name: Terraform Apply tfplan
+        run: |
+          echo "Terraform apply"
+          # terraform apply -auto-approve tfplan
+
+      - id: tf_hot_apply
+        if: steps.extract_pr_info.outputs.PR_NUMBER == 0
+        name: Terraform Fast Apply For Hotfix
+        run: terraform apply -auto-approve
+        env:
+          TF_VAR_location: ${{ secrets.AWS_REGION }}
+          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
+          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
+          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}

--- a/.github/workflows/dev-tf-apply.yml
+++ b/.github/workflows/dev-tf-apply.yml
@@ -64,8 +64,7 @@ jobs:
         if: steps.extract_pr_info.outputs.PR_NUMBER != 0
         name: Download Plan from S3
         run: |
-          echo "Download Tfplan File"
-          # aws s3 cp s3://${{ secrets.WORKFLOW_TEMP_BUCKET }}/plans/plan-${{ steps.extract_pr_info.outputs.PR_NUMBER }}_${{ env.tf_dir }} tfplan
+          aws s3 cp s3://${{ secrets.WORKFLOW_TEMP_BUCKET }}/plans/plan-${{ steps.extract_pr_info.outputs.PR_NUMBER }}_${{ env.tf_dir }} tfplan
           if [ $? -ne 0 ]; then
             echo "Failed to retrieve planfile. It may have expired or been deleted."
             exit 1
@@ -75,7 +74,7 @@ jobs:
         if: steps.extract_pr_info.outputs.PR_NUMBER != 0
         name: Terraform Apply tfplan
         run: |
-          echo "Terraform apply"
+          echo "Fake Terraform apply"
           # terraform apply -auto-approve tfplan
 
       - id: tf_hot_apply

--- a/.github/workflows/dev-tf-plan.yml
+++ b/.github/workflows/dev-tf-plan.yml
@@ -45,18 +45,13 @@ jobs:
           terraform_dir: ${{ env.tf_dir }}
           terraform_version: ${{ env.tf_version }}
           backend_region: ${{ secrets.TF_BACKEND_REGION }}
-          backend_role_arn: "arn:aws:iam::${{ secrets.AWS_DEV_ORG_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          backend_role_arn: "arn:aws:iam::${{ secrets.AWS_DEV_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
           backend_state_bucket: ${{ secrets.TF_BACKEND_STATE_BUCKET }}
           backend_lockid_table: ${{ secrets.TF_BACKEND_LOCKID_TABLE }}
 
       - id: tf_plan
         name: Terraform Plan
         run: terraform plan -out .planfile
-        env:
-          TF_VAR_location: ${{ secrets.AWS_REGION }}
-          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
-          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
-          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}
 
       - id: post_comment
         name: Post Terraform Plan to PR

--- a/.github/workflows/dev-tf-plan.yml
+++ b/.github/workflows/dev-tf-plan.yml
@@ -1,0 +1,72 @@
+name: Dev - Terraform Plan
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "dev/**"
+      - ".github/workflows/dev-tf-plan.yml"
+
+permissions:
+  id-token: write # This is required for requesting the JWT (OIDC)
+  contents: read
+  pull-requests: write
+
+jobs:
+  dev_terraform_plan:
+    environment:
+      name: Development
+    env:
+      tf_version: "1.10.2"
+      tf_dir: "dev"
+
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ${{ env.tf_dir }}
+
+    if: github.event.pull_request.state != 'approved'
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+
+      - id: checkout_common_action
+        name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          repository: Innovate-Future-Foundation/common-action
+          path: common-action
+
+      - id: tf_prep
+        name: Terraform setup using oidc role
+        uses: ./common-action/setup-tf-aws
+        with:
+          terraform_dir: ${{ env.tf_dir }}
+          terraform_version: ${{ env.tf_version }}
+          backend_region: ${{ secrets.TF_BACKEND_REGION }}
+          backend_role_arn: "arn:aws:iam::${{ secrets.AWS_DEV_ORG_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          backend_state_bucket: ${{ secrets.TF_BACKEND_STATE_BUCKET }}
+          backend_lockid_table: ${{ secrets.TF_BACKEND_LOCKID_TABLE }}
+
+      - id: tf_plan
+        name: Terraform Plan
+        run: terraform plan -out .planfile
+        env:
+          TF_VAR_location: ${{ secrets.AWS_REGION }}
+          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
+          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
+          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}
+
+      - id: post_comment
+        name: Post Terraform Plan to PR
+        uses: borchero/terraform-plan-comment@v2
+        with:
+          working-directory: ${{ env.tf_dir }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          planfile: .planfile
+
+      - name: Upload Plan to S3
+        run: |
+          aws s3 cp .planfile s3://${{ secrets.WORKFLOW_TEMP_BUCKET }}/plans/plan-${{ github.event.pull_request.number }}_${{ env.tf_dir }}
+          echo "Plan uploaded to S3"


### PR DESCRIPTION
# Summary
This copies tf pipelines form access-control with adoptions to use new [common-action](https://github.com/Innovate-Future-Foundation/common-action) repository.

# Details
common-action
- setup-tf-aws
  This is the original `setup_with_oidc` composite action which init terraform and aws authentications
- extract-pr-info
  This is the original step `get_pr_number` in terraform CD pipeline, this now returns pr numbers, pr commit hash, and a tag consists of <commit_hash>_<pr_number>