### PR TITLE
feat: add ECR module with repository configurations

### DIFF
--- a/dev/.terraform.lock.hcl
+++ b/dev/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.86.0"
   constraints = "~> 5.1"
   hashes = [
+    "h1:UpRjlmF+Xi6q4YxMMlN/66sCI81VWJOKiumk1cfBptQ=",
     "h1:dVxrQ67Ikqv/1/rfopK/wvCdETlUbQ6ZFuNOH+vEWqs=",
     "zh:1587c6a0199dc33d066c13e1628bc0dd966d7d6740cb2007b636524a3ec99430",
     "zh:15af46cc5bb43a37c24438cb3a36d44209a89d923ea4d4d631b56b1a89717b26",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.6.3"
   hashes = [
     "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -77,7 +77,7 @@ module "ecr" {
 
   repositories = {
     api-server = {
-      name        = "inff/api-server"
+      name        = "inff/backend-publish"
       description = "API server container images"
     }
     base-server = {

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -76,11 +76,11 @@ module "ecr" {
   source = "../modules/ecr"
 
   repositories = {
-    api-server = {
+    backend-publish = {
       name        = "inff/backend-publish"
       description = "API server container images"
     }
-    base-server = {
+    backend-base = {
       name        = "inff/backend-base"
       description = "Base server container images"
     }

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -81,7 +81,7 @@ module "ecr" {
       description = "API server container images"
     }
     base-server = {
-      name        = "inff/base-server"
+      name        = "inff/backend-base"
       description = "Base server container images"
     }
   }

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -71,3 +71,20 @@ module "cloud_map" {
   description = "Namespace for InFF Dev Enviroment"
   vpc_id      = module.network.vpc_id
 }
+
+module "ecr" {
+  source = "../modules/ecr"
+
+  repositories = {
+    api-server = {
+      name        = "inff/api-server"
+      description = "API server container images"
+    }
+    base-server = {
+      name        = "inff/base-server"
+      description = "Base server container images"
+    }
+  }
+
+  tags = local.general_tags
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,38 @@
+resource "aws_ecr_repository" "repo" {
+  for_each             = var.repositories
+  name                 = each.value.name
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = each.value.name
+    }
+  )
+}
+
+resource "aws_ecr_lifecycle_policy" "policy" {
+  for_each   = var.repositories
+  repository = aws_ecr_repository.repo[each.key].name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 30 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 30
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,13 @@
+output "repository_urls" {
+  description = "Map of repository names to repository URLs"
+  value = {
+    for k, v in aws_ecr_repository.repo : k => v.repository_url
+  }
+}
+
+output "repository_arns" {
+  description = "Map of repository names to repository ARNs"
+  value = {
+    for k, v in aws_ecr_repository.repo : k => v.arn
+  }
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,13 @@
+variable "repositories" {
+  description = "Map of ECR repositories to create"
+  type = map(object({
+    name        = string
+    description = string
+  }))
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/network/vpc.tf
+++ b/modules/network/vpc.tf
@@ -46,8 +46,8 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  for_each       = aws_subnet.public
-  subnet_id      = each.value.id
+  for_each       = var.public_subnets
+  subnet_id      = aws_subnet.public[each.key].id
   route_table_id = aws_route_table.public.id
 }
 
@@ -61,7 +61,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route_table_association" "private" {
-  for_each       = aws_subnet.private
-  subnet_id      = each.value.id
+  for_each       = var.private_subnets
+  subnet_id      = aws_subnet.private[each.key].id
   route_table_id = aws_route_table.private.id
 }


### PR DESCRIPTION
# ECR Module for Container Registry Management
This PR implements an Amazon Elastic Container Registry (ECR) module to manage private repositories for the Inff project's container images.

## Key Changes:
- Created ECR module with support for multiple repositories
- Configured two private repositories: inff/api-server and inff/base-server
- Implemented image tag immutability for version control
- Set up automatic image scanning on push
- Added lifecycle policy to maintain last 30 images
- Configured repository tags for resource management
- Added module outputs for repository URLs and ARNs

## Test Method:
- Imported existing ECR repositories into Terraform state
- Verified repository configurations and settings
- Confirmed image tag immutability settings
- Validated image scanning configuration
- Tested lifecycle policy implementation
- Verified repository tagging
- Confirmed repository URLs are accessible

## Related Ticket
[JIRA Ticket: IF-269](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-269)