### PR TITLE
fix: add missing prefix for log group

### DIFF
--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -25,7 +25,7 @@ variable "role_name" {
 
 variable "ecs_logs_group" {
   description = "CloudWatch logs group for backend service on ecs"
-  default     = "ecs/default_log_group"
+  default     = "inff/ecs/default_log_group"
   type        = string
 }
 


### PR DESCRIPTION
Add inff/ prefix to cloud watch logs group, as we only provide permissions to manage log groups following inff/* pattern 