### PR TITLE
fix: increase start period and health check timeout

### DIFF
--- a/dev/backend-task-def-template.json
+++ b/dev/backend-task-def-template.json
@@ -56,10 +56,10 @@
         "CMD-SHELL",
         "rabbitmq-diagnostics check_running"
       ],
-      "interval": 10,
-      "timeout": 3,
+      "interval": 30,
+      "timeout": 10,
       "retries": 3,
-      "startPeriod": 10
+      "startPeriod": 25
     },
     "logConfiguration": {
       "logDriver": "awslogs",


### PR DESCRIPTION
## Summary
Due to the capacity limit for dev ecs, I increased the health check start period and timeout.
- interval 30s
- start period 25s
- timeout 10s